### PR TITLE
Fix atom-text-editor deprecation

### DIFF
--- a/grammars/apex.cson
+++ b/grammars/apex.cson
@@ -814,7 +814,7 @@
     'captures':
       '1':
         'name': 'storage.modifier.apex'
-    'match': '\\b(public|private|protected|static|final|native|synchronized|abstract|threadsafe|transient)\\b'
+    'match': '\\b(global|public|private|protected|static|final|native|synchronized|abstract|threadsafe|transient)\\b'
   'strings':
     'patterns': [
       {
@@ -880,7 +880,7 @@
     'applyEndPatternLast': 1
     'patterns': [
       {
-        'begin': '(?x:(?=\n                        (?:\n                            (?:private|protected|public|native|synchronized|abstract|threadsafe|transient|static|final) # visibility/modifier\n                                |\n                            (?:def)\n                                |\n                            (?:void|boolean|byte|char|short|int|float|long|double)\n                                |\n                            (?:(?:[a-z]\\w*\\.)*[A-Z]+\\w*) # object type\n                        )\n                        \\s+\n                        (?!private|protected|public|native|synchronized|abstract|threadsafe|transient|static|final|def|void|boolean|byte|char|short|int|float|long|double)\n                        [\\w\\d_<>\\[\\],\\?][\\w\\d_<>\\[\\],\\? \\t]*\n                        (?:=|$)\n                        \n\t\t\t\t\t))'
+        'begin': '(?x:(?=\n                        (?:\n                            (?:private|protected|public|global|native|synchronized|abstract|threadsafe|transient|static|final) # visibility/modifier\n                                |\n                            (?:def)\n                                |\n                            (?:void|boolean|byte|char|short|int|float|long|double)\n                                |\n                            (?:(?:[a-z]\\w*\\.)*[A-Z]+\\w*) # object type\n                        )\n                        \\s+\n                        (?!private|protected|public|global|native|synchronized|abstract|threadsafe|transient|static|final|def|void|boolean|byte|char|short|int|float|long|double)\n                        [\\w\\d_<>\\[\\],\\?][\\w\\d_<>\\[\\],\\? \\t]*\n                        (?:=|$)\n                        \n\t\t\t\t\t))'
         'end': '(?=;)'
         'name': 'meta.definition.variable.apex'
         'patterns': [

--- a/styles/mavensmate-atom.less
+++ b/styles/mavensmate-atom.less
@@ -476,7 +476,7 @@ svg.busy circle.circle3 {
   @keyframes animate-stripes { 100% { background-position: -100px 0; } }
 }
 
-atom-text-editor .gutter {
+atom-text-editor::shadow .gutter {
   div.line-number.mm-checkpoint-gutter {
     background: #009edf;
   }


### PR DESCRIPTION
Selecting 'atom-text-editor' directly is deprecated in Atom LESS files. Atom warns to instead use 'atom-text-editor::shadow'.