### PR TITLE
Added code to append "Test" and run tests if this is not a test class

### DIFF
--- a/keymaps/mavensmate.cson
+++ b/keymaps/mavensmate.cson
@@ -6,7 +6,7 @@
   'ctrl-alt-s': 'mavensmate:compile'
   'ctrl-alt-p': 'mavensmate:compile-project'
   'ctrl-alt-x': 'mavensmate:run-apex-script'
-  'ctrl-alt-a': 'mavensmate:run-tests'
+  'ctrl-alt-a': 'mavensmate:run-tests-for-this-class'
   'ctrl-alt-l': 'mavensmate:start-logging'
   'ctrl-alt-k': 'mavensmate:fetch-logs'
   'ctrl-alt-t': 'mavensmate:run-all-tests'

--- a/lib/commands.json
+++ b/lib/commands.json
@@ -121,7 +121,7 @@
           "buttons": ["Yes", "No"]
         },
         "panelMessage": "Refreshing",
-        "scope": "project"           
+        "scope": "project"
     },
     {
         "atomName": "edit-project",
@@ -197,13 +197,20 @@
         "panelMessage": "Opening Apex unit test UI",
         "scope": "project"
     },
-    {
+	{
         "atomName": "run-tests",
         "coreName": "run-tests",
         "classes": "activeBaseName",
         "panelMessage": "Running Apex unit tests",
         "scope": "project"
     },
+  	{
+  		"atomName": "run-tests-for-this-class",
+  		"coreName": "run-tests",
+  		"classes": "activeBaseNameTest",
+  		"panelMessage": "Running Apex unit tests",
+  		"scope": "project"
+  	},
     {
         "atomName": "deploy-to-server",
         "coreName": "deploy",

--- a/lib/mavensmate.coffee
+++ b/lib/mavensmate.coffee
@@ -236,6 +236,11 @@ module.exports =
               when 'activeBaseName'
                 if util.activeFile().indexOf('.cls') >= 0
                   payload.classes = [util.activeFileBaseName().split('.')[0]]
+              when 'activeBaseNameTest'
+                if util.activeFile().indexOf('Test.cls') >= 0
+                  payload.classes = [util.activeFileBaseName().split('.')[0]]
+                else if util.activeFile().indexOf('.cls') >= 0
+                  payload.classes = [util.activeFileBaseName().split('.')[0] + 'Test']
           if 'payloadMetadata' of cmd
             payload.args.type = cmd.payloadMetadata
 

--- a/menus/mavensmate.cson
+++ b/menus/mavensmate.cson
@@ -109,6 +109,10 @@
             'label': 'Run Tests For This Apex Class',
             'command': 'mavensmate:run-tests'
           }
+          {
+            'label': 'Run Tests For This Apex Class\' Test Class',
+            'command': 'mavensmate:run-tests-for-this-class'
+          }
         ]
       }
       {


### PR DESCRIPTION
This means you can use the same keyboard shortcut to run tests in a testclass and to run tests for this class. For example, calling "run-all-tests-for-this-class" on "DateTimeUtilsTest" will run the tests in "DateTimeUtilsTest". Calling it on "DateTimeUtils" will run tests in "DateTimeUtilsTest'.